### PR TITLE
Demo course needs to be tagged for releases

### DIFF
--- a/openedx.yaml
+++ b/openedx.yaml
@@ -2,4 +2,6 @@
 # http://open-edx-proposals.readthedocs.io/en/latest/oeps/oep-0002.html#specification
 
 oeps: {}
+openedx-release:
+    ref: master
 owner: edx/testeng


### PR DESCRIPTION
Fun true story! The OEP-2 work broke installing devstack! Wheee! This is
part of the fix.