### PR TITLE
Fix readme download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ All code is made available under an [AGPLv3 License][agpl].
 
 [agpl]: AGPL_LICENSE
 [cc]: http://creativecommons.org/licenses/by-nc-sa/3.0/us/
-[gzipped tarball]: https://github.com/edx/edx-demo-course/releases/download/1.0/edx_demo_course_1_0.tar.gz
+[gzipped tarball]: https://github.com/edx/edx-demo-course/archive/open-release/ironwood.2.tar.gz


### PR DESCRIPTION
Previous version pointed to v1.0, which dates back from 2013. This
misleads users who try to install the old version in newer open edx
install. See for instance: https://github.com/overhangio/tutor/issues/256