### PR TITLE
fix: update print statements to python3 syntax (#28)

### DIFF
--- a/problem/python_grader.xml
+++ b/problem/python_grader.xml
@@ -73,7 +73,7 @@ while abs(balance) &gt; .02:
 
 # When the while loop terminates, we know we have 
 #  our answer!
-print "Lowest Payment:", round(payment, 2)
+print("Lowest Payment:", round(payment, 2))
 </answer_display>
       <grader_payload>
 {"grader": "ps02/bisect/grade_bisect.py"}

--- a/static/VGL/make
+++ b/static/VGL/make
@@ -33,7 +33,7 @@ def fix(fn, root, url):
         new = re.sub('i4x://MITx/7.00x/problem',inputs[root], new)
 
     open('%s/%s' % (root, os.path.basename(fn)),'w').write(new)
-    print "Processed %s (%s:%s)" % (fn, root, url)
+    print("Processed %s (%s:%s)" % (fn, root, url))
 
 for root, url in roots.items():
     for fn in glob.glob('original/*.jnlp'):


### PR DESCRIPTION
was merged into master here: https://github.com/edx/edx-demo-course/pull/28

**Context**

I fixed the Python-2-style `print` statement in the Python grader answer for edX.org's demo course recently, and wanted to "upstream" the fix here. Without this fix, the sample answer that the problem provides fails to run.

As for the other file I fixed -- I have no idea what that file does, but fixing the print statement can't hurt.